### PR TITLE
java.xml.soap has been a part of java.xml.ws ,so remove java.xml.soap…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -525,7 +525,7 @@ href='http://www.oracle.com/technetwork/java/index-jsp-137004.html'><i>Metro Web
                                 <includeDependencySources>false</includeDependencySources>
                                 <additionalJOptions>
                                     <additionalJOption>--add-modules</additionalJOption>
-                                    <additionalJOption>java.xml.soap,java.xml.bind,java.xml.ws.annotation</additionalJOption>
+                                    <additionalJOption>java.xml.bind,java.xml.ws.annotation</additionalJOption>
                                     <additionalJOption>--module-path</additionalJOption>
                                     <additionalJOption>${mod.dir}</additionalJOption>
                                 </additionalJOptions>


### PR DESCRIPTION
From JDK-8067867, we can see java.xml.soap has been a part of java.xml.ws. So remove java.xml.soap from --add-modules.